### PR TITLE
fixed vim-mode autoCloseMath incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This simple plugin adds various shortcuts to speedup latex math typing.
 
 ### 1. Auto close \$ symbol + Move cursor between \$\$ symbols
 * Typing **\$** will automatically close with **\$** and shift the cursor in between the **\$\$** symbols.
-* **Tip:** If you use the $ symbol often as currency symbol, you may toggle off the "auto close math symbol" function in the plugin setting.     
+* **Tip:** If you use the $ symbol often as currency symbol, you may toggle off the "auto close math symbol" function in the plugin setting.
 
 ![auto Move into Math](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoCloseMath.gif)
 
 ### 2. Autoclose {}, [], () brackets
-* Typing **"{"**, **"["** and **"("** will automatically close with **"}"**,**"]"** or **")"**.  
+* Typing **"{"**, **"["** and **"("** will automatically close with **"}"**,**"]"** or **")"**.
 
 ### 3. Auto append "\limits" after "\sum"
 * Typing **"\sum"** will automatically append **"\limits"** to shorten the syntax for proper display of the limits for summation symbol.
@@ -25,7 +25,7 @@ This simple plugin adds various shortcuts to speedup latex math typing.
 ![auto Enlarge Bracket](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoEnlargeBracket.gif)
 
 ### 5. Auto enclose expression after superscipt with {}
-* Typing expressions after superscript **"^"** symbol follow by a **"space" key** will automatically surround the expressions with **"{}"**.  
+* Typing expressions after superscript **"^"** symbol follow by a **"space" key** will automatically surround the expressions with **"{}"**.
 
 ![auto Enclose Superscript](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoEncloseSup.gif)
 
@@ -34,58 +34,58 @@ This simple plugin adds various shortcuts to speedup latex math typing.
 
 ![auto Fraction](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoFraction.gif)
 
-* **Tip 1:** Enclose your fraction expression within round brackets () will help the system identify the boundaries of your fraction.  
+* **Tip 1:** Enclose your fraction expression within round brackets () will help the system identify the boundaries of your fraction.
 
 ![auto Fraction 1](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoFraction1%20-%20enclose%20with%20round%20bracket.gif)
 
-* **Tip 2:** Put a **space** infront of fraction to denote the start of the fraction. Especially useful for series of fractions!  
+* **Tip 2:** Put a **space** infront of fraction to denote the start of the fraction. Especially useful for series of fractions!
 
 ![auto Fraction 2](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoFraction2%20-%20space.gif)
 
-* **Tip 3:** For longer numerator or denominator expressions (especially when the expressions have white spaces which may trigger the frac-replace prematurely), enclose the expressions in round brackets **()**.  
+* **Tip 3:** For longer numerator or denominator expressions (especially when the expressions have white spaces which may trigger the frac-replace prematurely), enclose the expressions in round brackets **()**.
 
 ![auto Fraction 3](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoFraction3%20-%20numeratordenominator.gif)
 
-* **Tip 4:** The plugin will remove the outermost brackets in numerator and denominator.  
+* **Tip 4:** The plugin will remove the outermost brackets in numerator and denominator.
 
 ### 7. Shortcut for Align Block
-* use "Alt+Shift+A" (Mac: "Option+Shift+A") shortcut key to quickly insert **\begin{align\*} \end{align\*}** block  
+* use "Alt+Shift+A" (Mac: "Option+Shift+A") shortcut key to quickly insert **\begin{align\*} \end{align\*}** block
 
-* **Tip 1:** If you have already typed some expressions and want to add the \begin{align\*} and \end{align\*} to the front and back, you can first select the texts then press "Alt+Shift+A" (Mac: "Option+Shift+A").  
+* **Tip 1:** If you have already typed some expressions and want to add the \begin{align\*} and \end{align\*} to the front and back, you can first select the texts then press "Alt+Shift+A" (Mac: "Option+Shift+A").
 
-* **Tip 2: Quick next line syntax within align block**  
-    * pressing **"enter"** within an align block will automatically insert **\\\\** to the end of the line, go to next line and add the **"&"** symbol.  
+* **Tip 2: Quick next line syntax within align block**
+    * pressing **"enter"** within an align block will automatically insert **\\\\** to the end of the line, go to next line and add the **"&"** symbol.
     * press **"shift+enter"** to go to next line **without** adding these symbols.
 
 * **Tip 3: Changing parameter**
     * the default parameter "align*" can be changed in the plugin settings.
 
-* **Tip 4: Edit Short Cut**  
-    * You may edit the shortcut keys in **Settings -> Hotkeys**  
+* **Tip 4: Edit Short Cut**
+    * You may edit the shortcut keys in **Settings -> Hotkeys**
 
 ![add Align Block](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_alignblock.gif)
 
 ### 8. Shortcut for Matrix Block
-* use "Alt+Shift+M" (Mac: "Option+Shift+M") shortcut key to quickly insert **\begin{pmatrix} \end{pmatrix}** block  
+* use "Alt+Shift+M" (Mac: "Option+Shift+M") shortcut key to quickly insert **\begin{pmatrix} \end{pmatrix}** block
 
-* **Tip 1: quick next item and next line syntax within matrix block**  
+* **Tip 1: quick next item and next line syntax within matrix block**
     * pressing **"tab"** within a matrix block will automatically insert **" & "**.
     * pressing **"enter"** within a matrix block will automatically insert **" \\\\ "**.
-    * press **"shift+enter"** to go to next line **without** adding these symbols.  
+    * press **"shift+enter"** to go to next line **without** adding these symbols.
 
 * **Tip 2: Changing parameter**
     * the default parameter "pmatrix" can be changed in the plugin settings. e.g. matrix, bmatrix, Bmatrix, vmatrix, Vmatrix
 
 * **Tip 3: Edit Short Cut**
-    * You may edit the shortcut keys in **Settings -> Hotkeys**  
+    * You may edit the shortcut keys in **Settings -> Hotkeys**
 
 ![add Matrix Block](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_matrixblock.gif)
 
 ### **[NEW]** 9. Custom shorthand
 * Use two-letters custom shorthand for common latex strings. e.g. typing "al" followed by "space" key will replace with "\\alpha"
-* You may set your own custom shorthand in the plugin settings page. Separate the two-letters shorthand and the string with ":" and separate each set of shorthands with ",". 
+* You may set your own custom shorthand in the plugin settings page. Separate the two-letters shorthand and the string with ":" and separate each set of shorthands with ",".
 e.g. al:\\alpha, be:\\beta
-* Below is the list of default shorthand:  
+* Below is the list of default shorthand:
 
 |Shorthand|String|Shorthand|String|Shorthand|String|Shorthand|String|
 |:-------:|:----:|:-------:|:----:|:-------:|:----:|:-------:|:----:|
@@ -105,6 +105,7 @@ e.g. al:\\alpha, be:\\beta
 ## Note:
 * The repo depends on the latest Obsidian API (obsidian.d.ts) in Typescript Definition format, which is still in early alpha so might break anytime!
 * This is my first Obsidian Plugin project, bugs might be present. Please use with caution.
+* Compatible with builtin Vim-mode.
 
 ---
 ## Future:


### PR DESCRIPTION
Fixed an issue with the builtin vim-mode, where while being in normal-mode and using '$' to jump to end-of-line, the plugin would wrongly insert a single '$' sign.

How to reproduce the bug in the unfixed version: 
- enable builtin 'Vim key bindings'
- in normal-mode, press '$' to go to end-of-line

As an unexpected side effect, my editor also removed a lot of trailing whitespaces. If that is an issue, please tell me so I can correct it.