### PR TITLE
fixed vim-mode incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This simple plugin adds various shortcuts to speedup latex math typing.
 
 ### 1. Auto close \$ symbol + Move cursor between \$\$ symbols
 * Typing **\$** will automatically close with **\$** and shift the cursor in between the **\$\$** symbols.
-* **Tip:** If you use the $ symbol often as currency symbol, you may toggle off the "auto close math symbol" function in the plugin setting.     
+* **Tip:** If you use the $ symbol often as currency symbol, you may toggle off the "auto close math symbol" function in the plugin setting.
 
 ![auto Move into Math](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoCloseMath.gif)
 
 ### 2. Autoclose {}, [], () brackets
-* Typing **"{"**, **"["** and **"("** will automatically close with **"}"**,**"]"** or **")"**.  
+* Typing **"{"**, **"["** and **"("** will automatically close with **"}"**,**"]"** or **")"**.
 
 ### 3. Auto append "\limits" after "\sum"
 * Typing **"\sum"** will automatically append **"\limits"** to shorten the syntax for proper display of the limits for summation symbol.
@@ -25,7 +25,7 @@ This simple plugin adds various shortcuts to speedup latex math typing.
 ![auto Enlarge Bracket](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoEnlargeBracket.gif)
 
 ### 5. Auto enclose expression after superscipt with {}
-* Typing expressions after superscript **"^"** symbol follow by a **"space" key** will automatically surround the expressions with **"{}"**.  
+* Typing expressions after superscript **"^"** symbol follow by a **"space" key** will automatically surround the expressions with **"{}"**.
 
 ![auto Enclose Superscript](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoEncloseSup.gif)
 
@@ -34,58 +34,58 @@ This simple plugin adds various shortcuts to speedup latex math typing.
 
 ![auto Fraction](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoFraction.gif)
 
-* **Tip 1:** Enclose your fraction expression within round brackets () will help the system identify the boundaries of your fraction.  
+* **Tip 1:** Enclose your fraction expression within round brackets () will help the system identify the boundaries of your fraction.
 
 ![auto Fraction 1](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoFraction1%20-%20enclose%20with%20round%20bracket.gif)
 
-* **Tip 2:** Put a **space** infront of fraction to denote the start of the fraction. Especially useful for series of fractions!  
+* **Tip 2:** Put a **space** infront of fraction to denote the start of the fraction. Especially useful for series of fractions!
 
 ![auto Fraction 2](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoFraction2%20-%20space.gif)
 
-* **Tip 3:** For longer numerator or denominator expressions (especially when the expressions have white spaces which may trigger the frac-replace prematurely), enclose the expressions in round brackets **()**.  
+* **Tip 3:** For longer numerator or denominator expressions (especially when the expressions have white spaces which may trigger the frac-replace prematurely), enclose the expressions in round brackets **()**.
 
 ![auto Fraction 3](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_autoFraction3%20-%20numeratordenominator.gif)
 
-* **Tip 4:** The plugin will remove the outermost brackets in numerator and denominator.  
+* **Tip 4:** The plugin will remove the outermost brackets in numerator and denominator.
 
 ### 7. Shortcut for Align Block
-* use "Alt+Shift+A" (Mac: "Option+Shift+A") shortcut key to quickly insert **\begin{align\*} \end{align\*}** block  
+* use "Alt+Shift+A" (Mac: "Option+Shift+A") shortcut key to quickly insert **\begin{align\*} \end{align\*}** block
 
-* **Tip 1:** If you have already typed some expressions and want to add the \begin{align\*} and \end{align\*} to the front and back, you can first select the texts then press "Alt+Shift+A" (Mac: "Option+Shift+A").  
+* **Tip 1:** If you have already typed some expressions and want to add the \begin{align\*} and \end{align\*} to the front and back, you can first select the texts then press "Alt+Shift+A" (Mac: "Option+Shift+A").
 
-* **Tip 2: Quick next line syntax within align block**  
-    * pressing **"enter"** within an align block will automatically insert **\\\\** to the end of the line, go to next line and add the **"&"** symbol.  
+* **Tip 2: Quick next line syntax within align block**
+    * pressing **"enter"** within an align block will automatically insert **\\\\** to the end of the line, go to next line and add the **"&"** symbol.
     * press **"shift+enter"** to go to next line **without** adding these symbols.
 
 * **Tip 3: Changing parameter**
     * the default parameter "align*" can be changed in the plugin settings.
 
-* **Tip 4: Edit Short Cut**  
-    * You may edit the shortcut keys in **Settings -> Hotkeys**  
+* **Tip 4: Edit Short Cut**
+    * You may edit the shortcut keys in **Settings -> Hotkeys**
 
 ![add Align Block](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_alignblock.gif)
 
 ### 8. Shortcut for Matrix Block
-* use "Alt+Shift+M" (Mac: "Option+Shift+M") shortcut key to quickly insert **\begin{pmatrix} \end{pmatrix}** block  
+* use "Alt+Shift+M" (Mac: "Option+Shift+M") shortcut key to quickly insert **\begin{pmatrix} \end{pmatrix}** block
 
-* **Tip 1: quick next item and next line syntax within matrix block**  
+* **Tip 1: quick next item and next line syntax within matrix block**
     * pressing **"tab"** within a matrix block will automatically insert **" & "**.
     * pressing **"enter"** within a matrix block will automatically insert **" \\\\ "**.
-    * press **"shift+enter"** to go to next line **without** adding these symbols.  
+    * press **"shift+enter"** to go to next line **without** adding these symbols.
 
 * **Tip 2: Changing parameter**
     * the default parameter "pmatrix" can be changed in the plugin settings. e.g. matrix, bmatrix, Bmatrix, vmatrix, Vmatrix
 
 * **Tip 3: Edit Short Cut**
-    * You may edit the shortcut keys in **Settings -> Hotkeys**  
+    * You may edit the shortcut keys in **Settings -> Hotkeys**
 
 ![add Matrix Block](https://raw.githubusercontent.com/joeyuping/quick_latex_obsidian/master/demo%20gif/g_matrixblock.gif)
 
 ### **[NEW]** 9. Custom shorthand
 * Use two-letters custom shorthand for common latex strings. e.g. typing "al" followed by "space" key will replace with "\\alpha"
-* You may set your own custom shorthand in the plugin settings page. Separate the two-letters shorthand and the string with ":" and separate each set of shorthands with ",". 
+* You may set your own custom shorthand in the plugin settings page. Separate the two-letters shorthand and the string with ":" and separate each set of shorthands with ",".
 e.g. al:\\alpha, be:\\beta
-* Below is the list of default shorthand:  
+* Below is the list of default shorthand:
 
 |Shorthand|String|Shorthand|String|Shorthand|String|Shorthand|String|
 |:-------:|:----:|:-------:|:----:|:-------:|:----:|:-------:|:----:|
@@ -105,6 +105,7 @@ e.g. al:\\alpha, be:\\beta
 ## Note:
 * The repo depends on the latest Obsidian API (obsidian.d.ts) in Typescript Definition format, which is still in early alpha so might break anytime!
 * This is my first Obsidian Plugin project, bugs might be present. Please use with caution.
+* Compatible with builtin vim-mode.
 
 ---
 ## Future:

--- a/main.ts
+++ b/main.ts
@@ -1,879 +1,893 @@
 import {
-	App,
-	MarkdownView,
-	Plugin,
-	Editor,
-	PluginSettingTab,
-	Setting
+    App,
+    MarkdownView,
+    Plugin,
+    Editor,
+    PluginSettingTab,
+    Setting
 } from 'obsidian';
 
 interface QuickLatexSettings {
-	moveIntoMath_toggle: boolean;
-	autoCloseMath_toggle: boolean;
-	autoCloseRound_toggle: boolean;
-	autoCloseSquare_toggle: boolean;
-	autoCloseCurly_toggle: boolean;
-	addAlignBlock_toggle: boolean;
-	addAlignBlock_parameter: string;
-	addMatrixBlock_toggle: boolean;
-	addMatrixBlock_parameter: string;
-	autoFraction_toggle: boolean;
-	autoLargeBracket_toggle: boolean;
-	autoSumLimit_toggle: boolean;
-	autoEncloseSup_toggle: boolean;
-	customShorthand_toggle: boolean;
-	customShorthand_parameter: string
+    moveIntoMath_toggle: boolean;
+    autoCloseMath_toggle: boolean;
+    autoCloseRound_toggle: boolean;
+    autoCloseSquare_toggle: boolean;
+    autoCloseCurly_toggle: boolean;
+    addAlignBlock_toggle: boolean;
+    addAlignBlock_parameter: string;
+    addMatrixBlock_toggle: boolean;
+    addMatrixBlock_parameter: string;
+    autoFraction_toggle: boolean;
+    autoLargeBracket_toggle: boolean;
+    autoSumLimit_toggle: boolean;
+    autoEncloseSup_toggle: boolean;
+    customShorthand_toggle: boolean;
+    customShorthand_parameter: string
 }
 
 const DEFAULT_SETTINGS: QuickLatexSettings = {
-	moveIntoMath_toggle: true,
-	autoCloseMath_toggle: true,
-	autoCloseRound_toggle: true,
-	autoCloseSquare_toggle: true,
-	autoCloseCurly_toggle: true,
-	addAlignBlock_toggle: true,
-	addAlignBlock_parameter: "align*",
-	addMatrixBlock_toggle: true,
-	addMatrixBlock_parameter: "pmatrix",
-	autoFraction_toggle: true,
-	autoLargeBracket_toggle: true,
-	autoSumLimit_toggle: true,
-	autoEncloseSup_toggle: true,
-	customShorthand_toggle: true,
-	customShorthand_parameter: "sq:\\sqrt, al:\\alpha, be:\\beta, ga:\\gamma, Ga:\\Gamma, "+
-							"de:\\delta, De:\\Delta, ep:\\epsilon, ze:\\zeta, "+
-							"et:\\eta, th:\\theta, Th:\\Theta, io:\\iota, "+
-							"ka:\\kappa, la:\\lambda, La:\\Lambda, mu:\\mu, "+
-							"nu:\\nu, xi:\\xi, Xi:\\Xi, pi:\\pi, Pi:\\Pi, "+
-							"rh:\\rho, si:\\sigma, Si:\\Sigma, ta:\\tau, "+
-							"up:\\upsilon, Up:\\Upsilon, ph:\\phi, Ph:\\Phi, ch:\\chi, "+
-							"ps:\\psi, Ps:\\Psi, om:\\omega, Om:\\Omega"
+    moveIntoMath_toggle: true,
+    autoCloseMath_toggle: true,
+    autoCloseRound_toggle: true,
+    autoCloseSquare_toggle: true,
+    autoCloseCurly_toggle: true,
+    addAlignBlock_toggle: true,
+    addAlignBlock_parameter: "align*",
+    addMatrixBlock_toggle: true,
+    addMatrixBlock_parameter: "pmatrix",
+    autoFraction_toggle: true,
+    autoLargeBracket_toggle: true,
+    autoSumLimit_toggle: true,
+    autoEncloseSup_toggle: true,
+    customShorthand_toggle: true,
+    customShorthand_parameter: "sq:\\sqrt, al:\\alpha, be:\\beta, ga:\\gamma, Ga:\\Gamma, "+
+        "de:\\delta, De:\\Delta, ep:\\epsilon, ze:\\zeta, "+
+        "et:\\eta, th:\\theta, Th:\\Theta, io:\\iota, "+
+        "ka:\\kappa, la:\\lambda, La:\\Lambda, mu:\\mu, "+
+        "nu:\\nu, xi:\\xi, Xi:\\Xi, pi:\\pi, Pi:\\Pi, "+
+        "rh:\\rho, si:\\sigma, Si:\\Sigma, ta:\\tau, "+
+        "up:\\upsilon, Up:\\Upsilon, ph:\\phi, Ph:\\Phi, ch:\\chi, "+
+        "ps:\\psi, Ps:\\Psi, om:\\omega, Om:\\Omega"
 }
 
 export default class QuickLatexPlugin extends Plugin {
-	settings: QuickLatexSettings;
-	shorthand_array: string[][];
+    settings: QuickLatexSettings;
+    shorthand_array: string[][];
 
-	async onload() {
-		console.log('loading Quick-Latex plugin');
+    private vimAllow_autoCloseMath: boolean = true;
 
-		await this.loadSettings();
+    async onload() {
+        console.log('loading Quick-Latex plugin');
 
-		this.app.workspace.onLayoutReady(() => {
-			this.registerCodeMirror((cm: CodeMirror.Editor) => {
-				cm.on('keyup', this.handleKeyUp);
-				cm.on('keydown', this.handleKeyDown);
-			});
+        await this.loadSettings();
 
-			this.addSettingTab(new QuickLatexSettingTab(this.app, this));
+        this.app.workspace.onLayoutReady(() => {
+            this.registerCodeMirror((cm: CodeMirror.Editor) => {
+                cm.on('keyup', this.handleKeyUp);
+                cm.on('keydown', this.handleKeyDown);
+                cm.on('vim-mode-change', (modeObj: any) => {
+                    if(!modeObj || modeObj.mode === 'insert')
+                        this.vimAllow_autoCloseMath = true;
+                    else
+                        this.vimAllow_autoCloseMath = false;
+                });
+            });
 
-			this.addCommand({
-				id: 'addAlignBlock',
-				name: 'Add Align Block',
-				hotkeys: [
-					{
-						modifiers: ['Alt', 'Shift'],
-						key: 'A',
-					},
-				],
-				editorCallback: (editor) => this.addAlignBlock(editor),
-			});
+            this.addSettingTab(new QuickLatexSettingTab(this.app, this));
 
-			this.addCommand({
-				id: 'addMatrixBlock',
-				name: 'Add Matrix Block',
-				hotkeys: [
-					{
-						modifiers: ['Alt', 'Shift'],
-						key: 'M',
-					},
-				],
-				editorCallback: (editor) => this.addMatrixBlock(editor),
-			});
+            this.addCommand({
+                id: 'addAlignBlock',
+                name: 'Add Align Block',
+                hotkeys: [
+                    {
+                        modifiers: ['Alt', 'Shift'],
+                        key: 'A',
+                    },
+                ],
+                editorCallback: (editor) => this.addAlignBlock(editor),
+            });
 
-			// preprocess shorthand array
-			this.shorthand_array = this.settings.customShorthand_parameter.split(",").map(item=>item.split(":").map(s=>s.trim()));
-		});
+            this.addCommand({
+                id: 'addMatrixBlock',
+                name: 'Add Matrix Block',
+                hotkeys: [
+                    {
+                        modifiers: ['Alt', 'Shift'],
+                        key: 'M',
+                    },
+                ],
+                editorCallback: (editor) => this.addMatrixBlock(editor),
+            });
+
+            // preprocess shorthand array
+            this.shorthand_array = this.settings.customShorthand_parameter.split(",").map(item=>item.split(":").map(s=>s.trim()));
+        });
 
 
-	}
+    }
 
-	public onunload(): void {
-		console.log('unloading Quick-Latex plugin');
+    public onunload(): void {
+        console.log('unloading Quick-Latex plugin');
 
-		this.app.workspace.iterateCodeMirrors((cm) => {
-			cm.off('keyup', this.handleKeyUp);
-			cm.off('keydown', this.handleKeyDown);
-		});
-	}
+        this.app.workspace.iterateCodeMirrors((cm) => {
+            cm.off('keyup', this.handleKeyUp);
+            cm.off('keydown', this.handleKeyDown);
+            cm.off('vim-mode-change', (modeObj: any) => {
+                  if(!modeObj || modeObj.mode === 'insert')
+                        this.vimAllow_autoCloseMath = true;
+                  else
+                        this.vimAllow_autoCloseMath = false;
+            });
+        });
+    }
 
-	//triggering functions
-	private readonly handleKeyDown = (
-		cm: CodeMirror.Editor,
-		event: KeyboardEvent,
-	): void => {
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-		if (!view) return;
+    //triggering functions
+    private readonly handleKeyDown = (
+        cm: CodeMirror.Editor,
+        event: KeyboardEvent,
+    ): void => {
+        const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+        if (!view) return;
 
-		const editor = view.editor;
+        const editor = view.editor;
 
-		if (['$', ' ', 'Enter', 'Tab'].contains(event.key)) {
-			switch (event.key) {
-				case '$':
-					// perform autoCloseMath
-					if (this.settings.autoCloseMath_toggle) {
-						editor.replaceSelection("$");
-					}
+        if (['$', ' ', 'Enter', 'Tab'].contains(event.key)) {
+            switch (event.key) {
+                case '$':
+                    // perform autoCloseMath
+                    if (this.settings.autoCloseMath_toggle && this.vimAllow_autoCloseMath) {
+                    editor.replaceSelection("$");
+                }
 
-					// perform moveIntoMath
-					if (this.settings.moveIntoMath_toggle) {
-						const position = editor.getCursor();
-						const t = editor.getRange(
-							{ line: position.line, ch: position.ch - 1 }, 
-							{ line: position.line, ch: position.ch })
-						const t2 = editor.getRange(
-							{ line: position.line, ch: position.ch }, 
-							{ line: position.line, ch: position.ch + 1 })
-						const t_2 = editor.getRange(
-							{ line: position.line, ch: position.ch - 2 }, 
-							{ line: position.line, ch: position.ch })
-						if (t == '$' && t2 != '$') {
-							editor.setCursor({ line: position.line, ch: position.ch - 1 })
-						} else if (t_2 == '$$') {
-							editor.setCursor({ line: position.line, ch: position.ch - 1 })
-						};
-					}
+                // perform moveIntoMath
+                if (this.settings.moveIntoMath_toggle) {
+                    const position = editor.getCursor();
+                    const t = editor.getRange(
+                        { line: position.line, ch: position.ch - 1 },
+                        { line: position.line, ch: position.ch })
+                        const t2 = editor.getRange(
+                            { line: position.line, ch: position.ch },
+                            { line: position.line, ch: position.ch + 1 })
+                            const t_2 = editor.getRange(
+                                { line: position.line, ch: position.ch - 2 },
+                                { line: position.line, ch: position.ch })
+                                if (t == '$' && t2 != '$') {
+                                    editor.setCursor({ line: position.line, ch: position.ch - 1 })
+                                } else if (t_2 == '$$') {
+                                    editor.setCursor({ line: position.line, ch: position.ch - 1 })
+                                };
+                }
 
-					return;
+                return;
 
-				case ' ':
-					if (!this.settings.autoFraction_toggle &&
-						!this.settings.autoLargeBracket_toggle &&
-						!this.settings.autoEncloseSup_toggle &&
-						!this.settings.customShorthand_toggle) return;
+                case ' ':
+                    if (!this.settings.autoFraction_toggle &&
+                        !this.settings.autoLargeBracket_toggle &&
+                        !this.settings.autoEncloseSup_toggle &&
+                        !this.settings.customShorthand_toggle) return;
 
-					if (this.withinMath(cm, editor)) {
+                if (this.withinMath(cm, editor)) {
 
-						const position = editor.getCursor();
-						const current_line = editor.getLine(position.line);
-						const last_dollar = current_line.lastIndexOf('$', position.ch - 1);
+                    const position = editor.getCursor();
+                    const current_line = editor.getLine(position.line);
+                    const last_dollar = current_line.lastIndexOf('$', position.ch - 1);
 
-						// check for custom shorthand
-						if (this.settings.customShorthand_toggle) {
-							const keyword = editor.getRange(
-								{ line: position.line, ch: position.ch - 2 }, 
-								{ line: position.line, ch: position.ch }
-							)
-							for (let i = 0 ; i < this.shorthand_array.length ; i++) {
-								if (this.shorthand_array[i][0] == keyword) {
-									editor.replaceRange(this.shorthand_array[i][1],
-										{ line: position.line, ch: position.ch - 2 }, 
-										{ line: position.line, ch: position.ch })
-									event.preventDefault();
-									return;
-								}
-							}
-						}
+                    // check for custom shorthand
+                    if (this.settings.customShorthand_toggle) {
+                        const keyword = editor.getRange(
+                            { line: position.line, ch: position.ch - 2 },
+                            { line: position.line, ch: position.ch }
+                        )
+                        for (let i = 0 ; i < this.shorthand_array.length ; i++) {
+                            if (this.shorthand_array[i][0] == keyword) {
+                                editor.replaceRange(this.shorthand_array[i][1],
+                                                    { line: position.line, ch: position.ch - 2 },
+                                                    { line: position.line, ch: position.ch })
+                                                    event.preventDefault();
+                                                    return;
+                            }
+                        }
+                    }
 
-						// retrieve the last unbracketed superscript
-						let last_superscript = current_line.lastIndexOf('^', position.ch);
-						while (last_superscript != -1) {
-							const letter_after_superscript = editor.getRange(
-								{ line: position.line, ch: last_superscript + 1 }, 
-								{ line: position.line, ch: last_superscript + 2 });
-							if (letter_after_superscript == '{') {
-								last_superscript = current_line.lastIndexOf('^', last_superscript - 1);
-							} else {
-								break;
-							}
-						}
+                    // retrieve the last unbracketed superscript
+                    let last_superscript = current_line.lastIndexOf('^', position.ch);
+                    while (last_superscript != -1) {
+                        const letter_after_superscript = editor.getRange(
+                            { line: position.line, ch: last_superscript + 1 },
+                            { line: position.line, ch: last_superscript + 2 });
+                            if (letter_after_superscript == '{') {
+                                last_superscript = current_line.lastIndexOf('^', last_superscript - 1);
+                            } else {
+                                break;
+                            }
+                    }
 
-						// retrieve the last divide symbol
-						let last_divide = current_line.lastIndexOf('/', position.ch - 1);
-						while (editor.getRange(
-							{ line: position.line, ch: last_divide - 1 }, 
-							{ line: position.line, ch: last_divide }
-							) == '\\') {
-							last_divide = current_line.lastIndexOf('/', last_divide - 1);
-						}
+                    // retrieve the last divide symbol
+                    let last_divide = current_line.lastIndexOf('/', position.ch - 1);
+                    while (editor.getRange(
+                        { line: position.line, ch: last_divide - 1 },
+                    { line: position.line, ch: last_divide }
+                    ) == '\\') {
+                        last_divide = current_line.lastIndexOf('/', last_divide - 1);
+                    }
 
-						// perform autoEncloseSup
-						if (this.settings.autoEncloseSup_toggle) {
-							if (last_superscript > last_divide) {
-								this.autoEncloseSup(editor, event, last_superscript);
-								return;
-							};
-						};
+                    // perform autoEncloseSup
+                    if (this.settings.autoEncloseSup_toggle) {
+                        if (last_superscript > last_divide) {
+                            this.autoEncloseSup(editor, event, last_superscript);
+                            return;
+                        };
+                    };
 
-						// perform autoFraction
-						if (this.settings.autoFraction_toggle) {
-							if (last_divide > last_dollar) {
-								const brackets = [['(', ')'], ['{', '}'], ['[', ']']];
-								// if any brackets in denominator still unclosed, dont do autoFraction yet
-								if (!brackets.some(e => this.unclosed_bracket(editor, e[0], e[1], position.ch, last_divide)[0])) {
-									this.autoFraction(editor, event, last_superscript);
-									return;
-								};
-							};
-						};
+                    // perform autoFraction
+                    if (this.settings.autoFraction_toggle) {
+                        if (last_divide > last_dollar) {
+                            const brackets = [['(', ')'], ['{', '}'], ['[', ']']];
+                            // if any brackets in denominator still unclosed, dont do autoFraction yet
+                            if (!brackets.some(e => this.unclosed_bracket(editor, e[0], e[1], position.ch, last_divide)[0])) {
+                                this.autoFraction(editor, event, last_superscript);
+                                return;
+                            };
+                        };
+                    };
 
-						// perform autoLargeBracket
-						if (this.settings.autoLargeBracket_toggle) {
-							let symbol_before = editor.getRange(
-								{ line: position.line, ch: position.ch - 1 }, 
-								{ line: position.line, ch: position.ch })
-							if (symbol_before == ')' || symbol_before == ']') {
-								this.autoLargeBracket(editor, event);
-								return;
-							};
-						}
+                    // perform autoLargeBracket
+                    if (this.settings.autoLargeBracket_toggle) {
+                        let symbol_before = editor.getRange(
+                            { line: position.line, ch: position.ch - 1 },
+                            { line: position.line, ch: position.ch })
+                            if (symbol_before == ')' || symbol_before == ']') {
+                                this.autoLargeBracket(editor, event);
+                                return;
+                            };
+                    }
 
-					};
-					break;
+                };
+                break;
 
-				case 'Enter':
-					// perform Enter shortcut within matrix block
-					if (this.settings.addMatrixBlock_toggle) {
-						if (this.withinAnyBrackets_document(
-							cm,
-							editor,
-							'\\begin{' + this.settings.addMatrixBlock_parameter,
-							'\\end{' + this.settings.addMatrixBlock_parameter
-						)) {
-							if (!event.shiftKey) {
-								editor.replaceSelection(' \\\\ ')
-								event.preventDefault();
-							};
-							return;
-						}
-					}
+                case 'Enter':
+                    // perform Enter shortcut within matrix block
+                    if (this.settings.addMatrixBlock_toggle) {
+                    if (this.withinAnyBrackets_document(
+                        cm,
+                    editor,
+                    '\\begin{' + this.settings.addMatrixBlock_parameter,
+                    '\\end{' + this.settings.addMatrixBlock_parameter
+                    )) {
+                        if (!event.shiftKey) {
+                            editor.replaceSelection(' \\\\ ')
+                            event.preventDefault();
+                        };
+                        return;
+                    }
+                }
 
-					// perform Enter shortcut within align block
-					if (this.settings.addAlignBlock_toggle) {
-						if (this.withinAnyBrackets_document(
-							cm,
-							editor,
-							'\\begin{' + this.settings.addAlignBlock_parameter,
-							'\\end{' + this.settings.addAlignBlock_parameter)
-						) {
-							if (!event.shiftKey) {
-								editor.replaceSelection('\\\\\n&')
-								event.preventDefault();
-							};
-							return;
-						};
-					}
-					return;
+                // perform Enter shortcut within align block
+                if (this.settings.addAlignBlock_toggle) {
+                    if (this.withinAnyBrackets_document(
+                        cm,
+                    editor,
+                    '\\begin{' + this.settings.addAlignBlock_parameter,
+                    '\\end{' + this.settings.addAlignBlock_parameter)
+                       ) {
+                           if (!event.shiftKey) {
+                               editor.replaceSelection('\\\\\n&')
+                               event.preventDefault();
+                           };
+                           return;
+                       };
+                }
+                return;
 
-				case 'Tab':
-					// perform Tab shortcut within matrix block
-					if (this.settings.addMatrixBlock_toggle) {
-						if (this.withinAnyBrackets_document(
-							cm,
-							editor,
-							'\\begin{' + this.settings.addMatrixBlock_parameter,
-							'\\end{' + this.settings.addMatrixBlock_parameter
-						)) {
-							editor.replaceSelection(' & ')
-							event.preventDefault();
-						};
-						return;
-					};
-			};
-		};
-	};
+                case 'Tab':
+                    // perform Tab shortcut within matrix block
+                    if (this.settings.addMatrixBlock_toggle) {
+                    if (this.withinAnyBrackets_document(
+                        cm,
+                    editor,
+                    '\\begin{' + this.settings.addMatrixBlock_parameter,
+                    '\\end{' + this.settings.addMatrixBlock_parameter
+                    )) {
+                        editor.replaceSelection(' & ')
+                        event.preventDefault();
+                    };
+                    return;
+                };
+            };
+        };
+    };
 
-	private readonly handleKeyUp = (
-		cm: CodeMirror.Editor,
-		event: KeyboardEvent,
-	): void => {
+    private readonly handleKeyUp = (
+        cm: CodeMirror.Editor,
+        event: KeyboardEvent,
+    ): void => {
 
-		if (['{', '[', '(', 'm'].contains(event.key)) {
-			const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-			if (!view) return;
+        if (['{', '[', '(', 'm'].contains(event.key)) {
+            const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+            if (!view) return;
 
-			const editor = view.editor;
-			if (this.withinMath(cm, editor)) {
-				const position = editor.getCursor();
-				const brackets = [['(', ')'], ['{', '}'], ['[', ']']];
-				switch (event.key) {
-					case '{':
-						if (!this.settings.autoCloseCurly_toggle) return;
-						if (!this.withinAnyBrackets_inline(editor, brackets)) {
-							editor.replaceSelection('}')
-							editor.setCursor(position)
-						};
-						return;
-					case '[':
-						if (!this.settings.autoCloseSquare_toggle) return;
-						if (!this.withinAnyBrackets_inline(editor, brackets)) {
-							editor.replaceSelection(']')
-							editor.setCursor(position)
-						};
-						return;
-					case '(':
-						if (!this.settings.autoCloseRound_toggle) return;
-						if (!this.withinAnyBrackets_inline(editor, brackets)) {
-							editor.replaceSelection(')')
-							editor.setCursor(position)
-						};
-						return;
-					case 'm':
-						if (!this.settings.autoSumLimit_toggle) return;
-						if (editor.getRange(
-							{ line: position.line, ch: position.ch - 2 }, 
-							{ line: position.line, ch: position.ch }) == 'su') {
-							editor.replaceSelection('m\\limits')
-							event.preventDefault()
-							return;
-						};
-				};
-			};
-		};
-	};
+            const editor = view.editor;
+            if (this.withinMath(cm, editor)) {
+                const position = editor.getCursor();
+                const brackets = [['(', ')'], ['{', '}'], ['[', ']']];
+                switch (event.key) {
+                    case '{':
+                        if (!this.settings.autoCloseCurly_toggle) return;
+                    if (!this.withinAnyBrackets_inline(editor, brackets)) {
+                        editor.replaceSelection('}')
+                        editor.setCursor(position)
+                    };
+                    return;
+                    case '[':
+                        if (!this.settings.autoCloseSquare_toggle) return;
+                    if (!this.withinAnyBrackets_inline(editor, brackets)) {
+                        editor.replaceSelection(']')
+                        editor.setCursor(position)
+                    };
+                    return;
+                    case '(':
+                        if (!this.settings.autoCloseRound_toggle) return;
+                    if (!this.withinAnyBrackets_inline(editor, brackets)) {
+                        editor.replaceSelection(')')
+                        editor.setCursor(position)
+                    };
+                    return;
+                    case 'm':
+                        if (!this.settings.autoSumLimit_toggle) return;
+                    if (editor.getRange(
+                        { line: position.line, ch: position.ch - 2 },
+                    { line: position.line, ch: position.ch }) == 'su') {
+                        editor.replaceSelection('m\\limits')
+                        event.preventDefault()
+                        return;
+                    };
+                };
+            };
+        };
+    };
 
-	//main functions
-	private readonly autoEncloseSup = (
-		editor: Editor,
-		event: KeyboardEvent,
-		last_superscript: number
-	): void => {
-		// superscript bracketing
-		const position = editor.getCursor();
-		const current_line = editor.getLine(position.line)
-		const letter_before_cursor = editor.getRange(
-			{ line: position.line, ch: position.ch - 1 },
-			{ line: position.line, ch: position.ch }
-		)
+    //main functions
+    private readonly autoEncloseSup = (
+        editor: Editor,
+        event: KeyboardEvent,
+        last_superscript: number
+    ): void => {
+        // superscript bracketing
+        const position = editor.getCursor();
+        const current_line = editor.getLine(position.line)
+        const letter_before_cursor = editor.getRange(
+            { line: position.line, ch: position.ch - 1 },
+            { line: position.line, ch: position.ch }
+        )
 
-		if (last_superscript != -1) {
-			const letter_after_superscript = editor.getRange(
-				{ line: position.line, ch: last_superscript + 1 }, 
-				{ line: position.line, ch: last_superscript + 2 });
-			if (letter_after_superscript == '(' && letter_before_cursor == ')') {
-				editor.replaceRange(
-					'}', 
-					{ line: position.line, ch: position.ch - 1 }, 
-					{ line: position.line, ch: position.ch }
-					);
-				editor.replaceRange(
-					'{', 
-					{ line: position.line, ch: last_superscript + 1 }, 
-					{ line: position.line, ch: last_superscript + 2 }
-					);
-				event.preventDefault();
-				return;
-			} else {
-				const last_divide = current_line.indexOf('/', last_superscript) == -1 ? 999 : current_line.indexOf('/', last_superscript);
-				const sup_close_index = Math.min(last_divide, position.ch);
-				editor.replaceRange('}', { line: position.line, ch: sup_close_index });
-				editor.replaceRange('{', { line: position.line, ch: last_superscript + 1 });
-				event.preventDefault();
-				return;
-			}
-		} else {
-			return
-		}
-	};
+        if (last_superscript != -1) {
+            const letter_after_superscript = editor.getRange(
+                { line: position.line, ch: last_superscript + 1 },
+                { line: position.line, ch: last_superscript + 2 });
+                if (letter_after_superscript == '(' && letter_before_cursor == ')') {
+                    editor.replaceRange(
+                        '}',
+                        { line: position.line, ch: position.ch - 1 },
+                        { line: position.line, ch: position.ch }
+                    );
+                    editor.replaceRange(
+                        '{',
+                        { line: position.line, ch: last_superscript + 1 },
+                        { line: position.line, ch: last_superscript + 2 }
+                    );
+                    event.preventDefault();
+                    return;
+                } else {
+                    const last_divide = current_line.indexOf('/', last_superscript) == -1 ? 999 : current_line.indexOf('/', last_superscript);
+                    const sup_close_index = Math.min(last_divide, position.ch);
+                    editor.replaceRange('}', { line: position.line, ch: sup_close_index });
+                    editor.replaceRange('{', { line: position.line, ch: last_superscript + 1 });
+                    event.preventDefault();
+                    return;
+                }
+        } else {
+            return
+        }
+    };
 
-	private readonly autoFraction = (
-		editor: Editor,
-		event: KeyboardEvent,
-		last_superscript: number
-	): void => {
-		const position = editor.getCursor();
-		const current_line = editor.getLine(position.line);
-		let last_divide = current_line.lastIndexOf('/', position.ch - 1);
+    private readonly autoFraction = (
+        editor: Editor,
+        event: KeyboardEvent,
+        last_superscript: number
+    ): void => {
+        const position = editor.getCursor();
+        const current_line = editor.getLine(position.line);
+        let last_divide = current_line.lastIndexOf('/', position.ch - 1);
 
-		// if cursor is preceeded by a close bracket, and the corresponding open bracket
-		// is found before "/", remove the brackets and enclose whole expression using \frac
-		const letter_before_cursor = editor.getRange(
-			{ line: position.line, ch: position.ch - 1 },
-			{ line: position.line, ch: position.ch }
-		)
+        // if cursor is preceeded by a close bracket, and the corresponding open bracket
+        // is found before "/", remove the brackets and enclose whole expression using \frac
+        const letter_before_cursor = editor.getRange(
+            { line: position.line, ch: position.ch - 1 },
+            { line: position.line, ch: position.ch }
+        )
 
-		// if there are any brackets unclosed before divide symbol, 
-		// include the open brackets into stop_symbols
-		const brackets = [['(', ')'], ['{', '}'], ['[', ']']];
-		let stop_brackets = []
-		for (let i = 0; i < brackets.length; i++) {
-			if (letter_before_cursor == brackets[i][1]) {
-				const open_brackets = this.unclosed_bracket(editor, brackets[i][0], brackets[i][1], position.ch - 1, 0)[1]
-				const pos_of_the_open_bracket = open_brackets[open_brackets.length - 1]
-				if (pos_of_the_open_bracket < last_divide) {
-					editor.replaceRange(
-						'}', 
-						{ line: position.line, ch: position.ch - 1 }, 
-						{ line: position.line, ch: position.ch }
-						);
-					editor.replaceRange(
-						'}{', 
-						{ line: position.line, ch: last_divide }, 
-						{ line: position.line, ch: last_divide + 1 }
-						);
-					editor.replaceRange(
-						'\\frac{', 
-						{ line: position.line, ch: pos_of_the_open_bracket }, 
-						{ line: position.line, ch: pos_of_the_open_bracket + 1 }
-						);
-					event.preventDefault();
-					return;
-				}
-			}
-			stop_brackets.push(...this.unclosed_bracket(editor, brackets[i][0], brackets[i][1], last_divide, 0)[1])
-		}
+        // if there are any brackets unclosed before divide symbol,
+        // include the open brackets into stop_symbols
+        const brackets = [['(', ')'], ['{', '}'], ['[', ']']];
+        let stop_brackets = []
+        for (let i = 0; i < brackets.length; i++) {
+            if (letter_before_cursor == brackets[i][1]) {
+                const open_brackets = this.unclosed_bracket(editor, brackets[i][0], brackets[i][1], position.ch - 1, 0)[1]
+                const pos_of_the_open_bracket = open_brackets[open_brackets.length - 1]
+                if (pos_of_the_open_bracket < last_divide) {
+                    editor.replaceRange(
+                        '}',
+                        { line: position.line, ch: position.ch - 1 },
+                        { line: position.line, ch: position.ch }
+                    );
+                    editor.replaceRange(
+                        '}{',
+                        { line: position.line, ch: last_divide },
+                        { line: position.line, ch: last_divide + 1 }
+                    );
+                    editor.replaceRange(
+                        '\\frac{',
+                        { line: position.line, ch: pos_of_the_open_bracket },
+                        { line: position.line, ch: pos_of_the_open_bracket + 1 }
+                    );
+                    event.preventDefault();
+                    return;
+                }
+            }
+            stop_brackets.push(...this.unclosed_bracket(editor, brackets[i][0], brackets[i][1], last_divide, 0)[1])
+        }
 
-		let frac = 0
+        let frac = 0
 
-		// if numerator is enclosed by (), place frac in front of () and remove ()
-		let numerator_remove_bracket = 0
-		if (editor.getRange({ line: position.line, ch: last_divide - 1 }, { line: position.line, ch: last_divide }) == ')') {
-			const numerator_open_bracket = this.unclosed_bracket(editor, '(', ')', last_divide - 1, 0)[1].slice(-1)[0]
-			frac = numerator_open_bracket - 1;
-			numerator_remove_bracket = 1
-		} else {
-			const stop_symbols = ['$', '=', '>', '<', ',', '/', ' ']
-			const symbol_positions = stop_symbols.map(e => current_line.lastIndexOf(e, last_divide - 1))
-			frac = Math.max(last_superscript, ...symbol_positions, ...stop_brackets)
-		};
+        // if numerator is enclosed by (), place frac in front of () and remove ()
+        let numerator_remove_bracket = 0
+        if (editor.getRange({ line: position.line, ch: last_divide - 1 }, { line: position.line, ch: last_divide }) == ')') {
+            const numerator_open_bracket = this.unclosed_bracket(editor, '(', ')', last_divide - 1, 0)[1].slice(-1)[0]
+            frac = numerator_open_bracket - 1;
+            numerator_remove_bracket = 1
+        } else {
+            const stop_symbols = ['$', '=', '>', '<', ',', '/', ' ']
+            const symbol_positions = stop_symbols.map(e => current_line.lastIndexOf(e, last_divide - 1))
+            frac = Math.max(last_superscript, ...symbol_positions, ...stop_brackets)
+        };
 
-		// if denominator is enclosed by (), remove ()
-		const denominator = editor.getRange(
-			{ line: position.line, ch: last_divide + 1 },
-			{ line: position.line, ch: position.ch }
-		);
-		let denominator_remove_bracket = 0;
-		if (denominator.slice(-1)[0] == ')') {
-			const denominator_open_bracket = this.unclosed_bracket(editor, '(', ')', position.ch - 1, 0)[1].slice(-1)[0]
-			if (denominator_open_bracket == last_divide + 1) {
-				denominator_remove_bracket = 1;
-			};
-		};
+        // if denominator is enclosed by (), remove ()
+        const denominator = editor.getRange(
+            { line: position.line, ch: last_divide + 1 },
+            { line: position.line, ch: position.ch }
+        );
+        let denominator_remove_bracket = 0;
+        if (denominator.slice(-1)[0] == ')') {
+            const denominator_open_bracket = this.unclosed_bracket(editor, '(', ')', position.ch - 1, 0)[1].slice(-1)[0]
+            if (denominator_open_bracket == last_divide + 1) {
+                denominator_remove_bracket = 1;
+            };
+        };
 
-		// perform \frac replace
-		editor.replaceRange(
-			'}', 
-			{ line: position.line, ch: position.ch - denominator_remove_bracket }, 
-			{ line: position.line, ch: position.ch }
-			);
-		editor.replaceRange(
-			'}{', 
-			{ line: position.line, ch: last_divide - numerator_remove_bracket }, 
-			{ line: position.line, ch: last_divide + 1 + denominator_remove_bracket }
-			);
-		editor.replaceRange(
-			'\\frac{', 
-			{ line: position.line, ch: frac + 1 }, 
-			{ line: position.line, ch: frac + 1 + numerator_remove_bracket }
-			);
-		event.preventDefault();
-	};
+        // perform \frac replace
+        editor.replaceRange(
+            '}',
+            { line: position.line, ch: position.ch - denominator_remove_bracket },
+            { line: position.line, ch: position.ch }
+        );
+        editor.replaceRange(
+            '}{',
+            { line: position.line, ch: last_divide - numerator_remove_bracket },
+            { line: position.line, ch: last_divide + 1 + denominator_remove_bracket }
+        );
+        editor.replaceRange(
+            '\\frac{',
+            { line: position.line, ch: frac + 1 },
+            { line: position.line, ch: frac + 1 + numerator_remove_bracket }
+        );
+        event.preventDefault();
+    };
 
-	private readonly autoLargeBracket = (
-		editor: Editor,
-		event: KeyboardEvent,
-	): void => {
-		const position = editor.getCursor();
-		const current_line = editor.getLine(position.line);
-		const brackets = [['[', ']'], ['(', ')']];
-		let left_array: number[] = [];
-		let right_array: number[] = []
-		for (let i = 0; i < brackets.length; i++) {
-			left_array.push(...this.unclosed_bracket(editor, brackets[i][0], brackets[i][1], position.ch - 1, 0)[1])
-			right_array.push(...this.unclosed_bracket(editor, brackets[i][0], brackets[i][1], current_line.length, position.ch - 1, false)[1])
-		}
-		if (left_array.length > 0 || right_array.length > 0) {
-			const large_operators = ['\\sum', '\\int', '\\frac'];
-			if (
-				large_operators.some(e => current_line.lastIndexOf(e, position.ch - 1) > left_array[0]) == true
-			) {
-				for (let k = right_array.length - 1; k > -1; k--) {
-					// check if unclosed brackets already appended with \right 
-					let check_right = editor.getRange(
-						{ line: position.line, ch: right_array[k] - 6 }, 
-						{ line: position.line, ch: right_array[k] });
-					if (check_right != '\\right') {
-						editor.replaceRange('\\right', { line: position.line, ch: right_array[k] });
-					} else {
-						return;
-					};
-				};
+    private readonly autoLargeBracket = (
+        editor: Editor,
+        event: KeyboardEvent,
+    ): void => {
+        const position = editor.getCursor();
+        const current_line = editor.getLine(position.line);
+        const brackets = [['[', ']'], ['(', ')']];
+        let left_array: number[] = [];
+        let right_array: number[] = []
+        for (let i = 0; i < brackets.length; i++) {
+            left_array.push(...this.unclosed_bracket(editor, brackets[i][0], brackets[i][1], position.ch - 1, 0)[1])
+            right_array.push(...this.unclosed_bracket(editor, brackets[i][0], brackets[i][1], current_line.length, position.ch - 1, false)[1])
+        }
+        if (left_array.length > 0 || right_array.length > 0) {
+            const large_operators = ['\\sum', '\\int', '\\frac'];
+            if (
+                large_operators.some(e => current_line.lastIndexOf(e, position.ch - 1) > left_array[0]) == true
+            ) {
+                for (let k = right_array.length - 1; k > -1; k--) {
+                    // check if unclosed brackets already appended with \right
+                    let check_right = editor.getRange(
+                        { line: position.line, ch: right_array[k] - 6 },
+                        { line: position.line, ch: right_array[k] });
+                        if (check_right != '\\right') {
+                            editor.replaceRange('\\right', { line: position.line, ch: right_array[k] });
+                        } else {
+                            return;
+                        };
+                };
 
-				for (let j = left_array.length - 1; j > -1; j--) {
-					// check if unclosed brackets already appended with \left
-					let check_left = editor.getRange(
-						{ line: position.line, ch: left_array[j] - 5 }, 
-						{ line: position.line, ch: left_array[j] });
-					if (check_left != '\\left') {
-						editor.replaceRange('\\left', { line: position.line, ch: left_array[j] });
-					} else {
-						return;
-					};
-				};
-				event.preventDefault();
-			};
-		};
-	};
+                for (let j = left_array.length - 1; j > -1; j--) {
+                    // check if unclosed brackets already appended with \left
+                    let check_left = editor.getRange(
+                        { line: position.line, ch: left_array[j] - 5 },
+                        { line: position.line, ch: left_array[j] });
+                        if (check_left != '\\left') {
+                            editor.replaceRange('\\left', { line: position.line, ch: left_array[j] });
+                        } else {
+                            return;
+                        };
+                };
+                event.preventDefault();
+            };
+        };
+    };
 
-	private addAlignBlock(editor: Editor) {
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-		if (!view) return;
-		if (!this.settings.addAlignBlock_toggle) return;
-		const selected_text = editor.getSelection()
-		editor.replaceSelection(
-			'\\begin{' + this.settings.addAlignBlock_parameter + '}\n' +
-			selected_text +
-			'\n\\end{' + this.settings.addAlignBlock_parameter + '}'
-		);
-		const position = editor.getCursor();
-		editor.setCursor({ line: position.line - 1, ch: editor.getLine(position.line - 1).length })
-	}
+    private addAlignBlock(editor: Editor) {
+        const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+        if (!view) return;
+        if (!this.settings.addAlignBlock_toggle) return;
+        const selected_text = editor.getSelection()
+        editor.replaceSelection(
+            '\\begin{' + this.settings.addAlignBlock_parameter + '}\n' +
+                selected_text +
+                '\n\\end{' + this.settings.addAlignBlock_parameter + '}'
+        );
+        const position = editor.getCursor();
+        editor.setCursor({ line: position.line - 1, ch: editor.getLine(position.line - 1).length })
+    }
 
-	private addMatrixBlock(editor: Editor) {
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-		if (!view) return;
-		if (!this.settings.addMatrixBlock_toggle) return;
-		editor.replaceSelection(
-			'\\begin{' + this.settings.addMatrixBlock_parameter + '}' +
-			'\\end{' + this.settings.addMatrixBlock_parameter + '}'
-		);
-		const position = editor.getCursor();
-		const retract_length = ('\\end{' + this.settings.addMatrixBlock_parameter + '}').length
-		editor.setCursor({ line: position.line, ch: position.ch - retract_length })
-	}
+    private addMatrixBlock(editor: Editor) {
+        const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+        if (!view) return;
+        if (!this.settings.addMatrixBlock_toggle) return;
+        editor.replaceSelection(
+            '\\begin{' + this.settings.addMatrixBlock_parameter + '}' +
+                '\\end{' + this.settings.addMatrixBlock_parameter + '}'
+        );
+        const position = editor.getCursor();
+        const retract_length = ('\\end{' + this.settings.addMatrixBlock_parameter + '}').length
+        editor.setCursor({ line: position.line, ch: position.ch - retract_length })
+    }
 
-	//utility functions
-	private readonly unclosed_bracket = (
-		editor: Editor,
-		open_symbol: string,
-		close_symbol: string,
-		before: number,
-		after: number,
-		unclosed_open_symbol: boolean = true //false for unclosed_close_symbol
-	): [boolean, number[]] => {
-		// determine if there are unclosed bracket within the range specified by before and after
-		const position = editor.getCursor();
-		const text = editor.getRange(
-			{ line: position.line, ch: after }, 
-			{ line: position.line, ch: before });
-		let open_array: number[] = []
-		let close_array: number[] = []
-		for (let i = 0; i < text.length; i++) {
-			switch (text[i]) {
-				case open_symbol:
-					if (close_array.length > 0) {
-						close_array.pop()
-					} else {
-						open_array.push(after + i);
-					}
-					break;
-				case close_symbol:
-					if (open_array.length > 0) {
-						open_array.pop()
-					} else {
-						close_array.push(after + i);
-					}
-					break;
-			}
-		}
-		if (unclosed_open_symbol) {
-			return [open_array.length > 0, open_array];
-		} else {
-			return [close_array.length > 0, close_array];
-		}
+    //utility functions
+    private readonly unclosed_bracket = (
+        editor: Editor,
+        open_symbol: string,
+        close_symbol: string,
+        before: number,
+        after: number,
+        unclosed_open_symbol: boolean = true //false for unclosed_close_symbol
+    ): [boolean, number[]] => {
+        // determine if there are unclosed bracket within the range specified by before and after
+        const position = editor.getCursor();
+        const text = editor.getRange(
+            { line: position.line, ch: after },
+            { line: position.line, ch: before });
+            let open_array: number[] = []
+            let close_array: number[] = []
+            for (let i = 0; i < text.length; i++) {
+                switch (text[i]) {
+                    case open_symbol:
+                        if (close_array.length > 0) {
+                        close_array.pop()
+                    } else {
+                        open_array.push(after + i);
+                    }
+                    break;
+                    case close_symbol:
+                        if (open_array.length > 0) {
+                        open_array.pop()
+                    } else {
+                        close_array.push(after + i);
+                    }
+                    break;
+                }
+            }
+            if (unclosed_open_symbol) {
+                return [open_array.length > 0, open_array];
+            } else {
+                return [close_array.length > 0, close_array];
+            }
 
-	};
+    };
 
-	private readonly withinMath = (
-		cm: CodeMirror.Editor,
-		editor: Editor
-	): Boolean => {
-		// check if cursor within $$
-		const position = editor.getCursor()
-		const current_line = editor.getLine(position.line);
-		let cursor_index = position.ch
-		let from = 0;
-		let found = current_line.indexOf('$', from);
-		while (found != -1 && found < cursor_index) {
-			let next_char = editor.getRange(
-				{ line: position.line, ch: found + 1 }, 
-				{ line: position.line, ch: found + 2 })
-			let prev_char = editor.getRange(
-				{ line: position.line, ch: found - 1 }, 
-				{ line: position.line, ch: found })
-			if (next_char == '$' || prev_char == '$' || next_char == ' ') {
-				from = found + 1;
-				found = current_line.indexOf('$', from);
-				continue;
-			} else {
-				from = found + 1;
-				let next_found = current_line.indexOf('$', from);
-				if (next_found == -1) {
-					return false;
-				} else if (cursor_index > found && cursor_index <= next_found) {
-					return true;
-				} else {
-					from = next_found + 1;
-					found = current_line.indexOf('$', from);
-					continue;
-				}
-			}
-		}
+    private readonly withinMath = (
+        cm: CodeMirror.Editor,
+        editor: Editor
+    ): Boolean => {
+        // check if cursor within $$
+        const position = editor.getCursor()
+        const current_line = editor.getLine(position.line);
+        let cursor_index = position.ch
+        let from = 0;
+        let found = current_line.indexOf('$', from);
+        while (found != -1 && found < cursor_index) {
+            let next_char = editor.getRange(
+                { line: position.line, ch: found + 1 },
+                { line: position.line, ch: found + 2 })
+                let prev_char = editor.getRange(
+                    { line: position.line, ch: found - 1 },
+                    { line: position.line, ch: found })
+                    if (next_char == '$' || prev_char == '$' || next_char == ' ') {
+                        from = found + 1;
+                        found = current_line.indexOf('$', from);
+                        continue;
+                    } else {
+                        from = found + 1;
+                        let next_found = current_line.indexOf('$', from);
+                        if (next_found == -1) {
+                            return false;
+                        } else if (cursor_index > found && cursor_index <= next_found) {
+                            return true;
+                        } else {
+                            from = next_found + 1;
+                            found = current_line.indexOf('$', from);
+                            continue;
+                        }
+                    }
+        }
 
-		const document_text = editor.getValue();
-		cursor_index = cm.indexFromPos(position);
-		from = 0;
-		found = document_text.indexOf('$$', from);
-		let count = 0;
-		while (found != -1 && found < cursor_index) {
-			count += 1;
-			from = found + 1;
-			found = document_text.indexOf('$$', from);
-		}
-		return count % 2 == 1;
-	};
+        const document_text = editor.getValue();
+        cursor_index = cm.indexFromPos(position);
+        from = 0;
+        found = document_text.indexOf('$$', from);
+        let count = 0;
+        while (found != -1 && found < cursor_index) {
+            count += 1;
+            from = found + 1;
+            found = document_text.indexOf('$$', from);
+        }
+        return count % 2 == 1;
+    };
 
-	private readonly withinAnyBrackets_inline = (
-		editor: Editor,
-		brackets: string[][]
-	): Boolean => {
-		const position = editor.getCursor()
-		const current_line = editor.getLine(position.line);
-		return brackets.some(e => this.unclosed_bracket(editor, e[0], e[1], position.ch, 0)[0] &&
-			this.unclosed_bracket(editor, e[0], e[1], current_line.length, position.ch, false)[0])
-	};
+    private readonly withinAnyBrackets_inline = (
+        editor: Editor,
+        brackets: string[][]
+    ): Boolean => {
+        const position = editor.getCursor()
+        const current_line = editor.getLine(position.line);
+        return brackets.some(e => this.unclosed_bracket(editor, e[0], e[1], position.ch, 0)[0] &&
+                             this.unclosed_bracket(editor, e[0], e[1], current_line.length, position.ch, false)[0])
+    };
 
-	private readonly withinAnyBrackets_document = (
-		cm: CodeMirror.Editor,
-		editor: Editor,
-		open_symbol: string,
-		close_symbol: string
-	): Boolean => {
-		const document_text = editor.getValue();
-		const position = editor.getCursor()
-		let cursor_index = cm.indexFromPos(position);
+    private readonly withinAnyBrackets_document = (
+        cm: CodeMirror.Editor,
+        editor: Editor,
+        open_symbol: string,
+        close_symbol: string
+    ): Boolean => {
+        const document_text = editor.getValue();
+        const position = editor.getCursor()
+        let cursor_index = cm.indexFromPos(position);
 
-		// count open symbols
-		let from = 0;
-		let found = document_text.indexOf(open_symbol, from);
-		let count = 0;
-		while (found != -1 && found < cursor_index) {
-			count += 1;
-			from = found + 1;
-			found = document_text.indexOf(open_symbol, from);
-		}
-		const open_symbol_counts = count
+        // count open symbols
+        let from = 0;
+        let found = document_text.indexOf(open_symbol, from);
+        let count = 0;
+        while (found != -1 && found < cursor_index) {
+            count += 1;
+            from = found + 1;
+            found = document_text.indexOf(open_symbol, from);
+        }
+        const open_symbol_counts = count
 
-		// count close symbols
-		from = 0;
-		found = document_text.indexOf(close_symbol, from);
-		count = 0;
-		while (found != -1 && found < cursor_index) {
-			count += 1;
-			from = found + 1;
-			found = document_text.indexOf(close_symbol, from);
-		}
-		const close_symbol_counts = count
+        // count close symbols
+        from = 0;
+        found = document_text.indexOf(close_symbol, from);
+        count = 0;
+        while (found != -1 && found < cursor_index) {
+            count += 1;
+            from = found + 1;
+            found = document_text.indexOf(close_symbol, from);
+        }
+        const close_symbol_counts = count
 
-		return open_symbol_counts > close_symbol_counts;
-	};
+        return open_symbol_counts > close_symbol_counts;
+    };
 
-	// Settings load and save
-	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-	};
+    // Settings load and save
+    async loadSettings() {
+        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    };
 
 };
 
 
 class QuickLatexSettingTab extends PluginSettingTab {
-	plugin: QuickLatexPlugin;
+    plugin: QuickLatexPlugin;
 
-	constructor(app: App, plugin: QuickLatexPlugin) {
-		super(app, plugin);
-		this.plugin = plugin;
-	}
+    constructor(app: App, plugin: QuickLatexPlugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
 
-	public display(): void {
-		const { containerEl } = this;
-		containerEl.empty();
+    public display(): void {
+        const { containerEl } = this;
+        containerEl.empty();
 
-		containerEl.createEl('h2', { text: 'Quick Latex for Obsidian - Settings' });
+        containerEl.createEl('h2', { text: 'Quick Latex for Obsidian - Settings' });
 
-		new Setting(containerEl)
-			.setName('Autoclose $$ symbols')
-			.setDesc('Typing one $ symbol will automatically lose with another $ symbol '+
-					'(best used with "Move cursor between $$ symbols" function')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.autoCloseMath_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.autoCloseMath_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+        new Setting(containerEl)
+        .setName('Autoclose $$ symbols')
+        .setDesc('Typing one $ symbol will automatically lose with another $ symbol '+
+                 '(best used with "Move cursor between $$ symbols" function')
+        .addToggle((toggle) => toggle
+                   .setValue(this.plugin.settings.autoCloseMath_toggle)
+                   .onChange(async (value) => {
+                       this.plugin.settings.autoCloseMath_toggle = value;
+                       await this.plugin.saveData(this.plugin.settings);
+                       this.display();
+                   }));
 
-		new Setting(containerEl)
-			.setName('Move cursor between $$ symbols')
-			.setDesc('Typing two consecutive $ symbols will automatically shift the cursor in between the $$ symbols')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.moveIntoMath_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.moveIntoMath_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                   new Setting(containerEl)
+                   .setName('Move cursor between $$ symbols')
+                   .setDesc('Typing two consecutive $ symbols will automatically shift the cursor in between the $$ symbols')
+                   .addToggle((toggle) => toggle
+                              .setValue(this.plugin.settings.moveIntoMath_toggle)
+                              .onChange(async (value) => {
+                                  this.plugin.settings.moveIntoMath_toggle = value;
+                                  await this.plugin.saveData(this.plugin.settings);
+                                  this.display();
+                              }));
 
-		new Setting(containerEl)
-			.setName('Autoclose {} curly brackets')
-			.setDesc('Typing "{" will automatically close with "}"')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.autoCloseCurly_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.autoCloseCurly_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                              new Setting(containerEl)
+                              .setName('Autoclose {} curly brackets')
+                              .setDesc('Typing "{" will automatically close with "}"')
+                              .addToggle((toggle) => toggle
+                                         .setValue(this.plugin.settings.autoCloseCurly_toggle)
+                                         .onChange(async (value) => {
+                                             this.plugin.settings.autoCloseCurly_toggle = value;
+                                             await this.plugin.saveData(this.plugin.settings);
+                                             this.display();
+                                         }));
 
-		new Setting(containerEl)
-			.setName('Autoclose [] square brackets')
-			.setDesc('Typing "[" will automatically close with "]"')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.autoCloseSquare_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.autoCloseSquare_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                         new Setting(containerEl)
+                                         .setName('Autoclose [] square brackets')
+                                         .setDesc('Typing "[" will automatically close with "]"')
+                                         .addToggle((toggle) => toggle
+                                                    .setValue(this.plugin.settings.autoCloseSquare_toggle)
+                                                    .onChange(async (value) => {
+                                                        this.plugin.settings.autoCloseSquare_toggle = value;
+                                                        await this.plugin.saveData(this.plugin.settings);
+                                                        this.display();
+                                                    }));
 
-		new Setting(containerEl)
-			.setName('Autoclose () round brackets')
-			.setDesc('Typing "(" will automatically close with ")"')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.autoCloseRound_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.autoCloseRound_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                                    new Setting(containerEl)
+                                                    .setName('Autoclose () round brackets')
+                                                    .setDesc('Typing "(" will automatically close with ")"')
+                                                    .addToggle((toggle) => toggle
+                                                               .setValue(this.plugin.settings.autoCloseRound_toggle)
+                                                               .onChange(async (value) => {
+                                                                   this.plugin.settings.autoCloseRound_toggle = value;
+                                                                   await this.plugin.saveData(this.plugin.settings);
+                                                                   this.display();
+                                                               }));
 
-		new Setting(containerEl)
-			.setName('Auto append "\\limits" after "\\sum"')
-			.setDesc('Typing "\\sum" will automatically append "\\limits" to shorten the syntax' +
-				' for proper display of the limits for summation symbol.')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.autoSumLimit_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.autoSumLimit_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                                               new Setting(containerEl)
+                                                               .setName('Auto append "\\limits" after "\\sum"')
+                                                               .setDesc('Typing "\\sum" will automatically append "\\limits" to shorten the syntax' +
+                                                                        ' for proper display of the limits for summation symbol.')
+                                                               .addToggle((toggle) => toggle
+                                                                          .setValue(this.plugin.settings.autoSumLimit_toggle)
+                                                                          .onChange(async (value) => {
+                                                                              this.plugin.settings.autoSumLimit_toggle = value;
+                                                                              await this.plugin.saveData(this.plugin.settings);
+                                                                              this.display();
+                                                                          }));
 
-		new Setting(containerEl)
-			.setName('Auto enlarge brackets that contains \\sum, \\int or \\frac')
-			.setDesc('Place cursor right after a () or [] bracketed expression that contains either ' +
-				'\\sum, \\int or \\frac and press the space key, the outermost brackets will be' +
-				' appended with \\left and \\right in order to display larger brackets to enclose these big expressions.')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.autoLargeBracket_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.autoLargeBracket_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                                                          new Setting(containerEl)
+                                                                          .setName('Auto enlarge brackets that contains \\sum, \\int or \\frac')
+                                                                          .setDesc('Place cursor right after a () or [] bracketed expression that contains either ' +
+                                                                                   '\\sum, \\int or \\frac and press the space key, the outermost brackets will be' +
+                                                                                   ' appended with \\left and \\right in order to display larger brackets to enclose these big expressions.')
+                                                                          .addToggle((toggle) => toggle
+                                                                                     .setValue(this.plugin.settings.autoLargeBracket_toggle)
+                                                                                     .onChange(async (value) => {
+                                                                                         this.plugin.settings.autoLargeBracket_toggle = value;
+                                                                                         await this.plugin.saveData(this.plugin.settings);
+                                                                                         this.display();
+                                                                                     }));
 
-		new Setting(containerEl)
-			.setName('Auto enclose expression after superscipt with {}')
-			.setDesc('Typing expressions after superscript "^" symbol follow by a "space" key ' +
-				'will automatically surround the expressions with "{}"')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.autoEncloseSup_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.autoEncloseSup_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                                                                     new Setting(containerEl)
+                                                                                     .setName('Auto enclose expression after superscipt with {}')
+                                                                                     .setDesc('Typing expressions after superscript "^" symbol follow by a "space" key ' +
+                                                                                              'will automatically surround the expressions with "{}"')
+                                                                                     .addToggle((toggle) => toggle
+                                                                                                .setValue(this.plugin.settings.autoEncloseSup_toggle)
+                                                                                                .onChange(async (value) => {
+                                                                                                    this.plugin.settings.autoEncloseSup_toggle = value;
+                                                                                                    await this.plugin.saveData(this.plugin.settings);
+                                                                                                    this.display();
+                                                                                                }));
 
-		new Setting(containerEl)
-			.setName('Type "/" instead of \\frac{}{}')
-			.setDesc('Use "/" symbol for quickly typing fractions. eg. type "1/2" followed by a "space" key' +
-				' to transform to \\frac{1}{2}')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.autoFraction_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.autoFraction_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                                                                                new Setting(containerEl)
+                                                                                                .setName('Type "/" instead of \\frac{}{}')
+                                                                                                .setDesc('Use "/" symbol for quickly typing fractions. eg. type "1/2" followed by a "space" key' +
+                                                                                                         ' to transform to \\frac{1}{2}')
+                                                                                                .addToggle((toggle) => toggle
+                                                                                                           .setValue(this.plugin.settings.autoFraction_toggle)
+                                                                                                           .onChange(async (value) => {
+                                                                                                               this.plugin.settings.autoFraction_toggle = value;
+                                                                                                               await this.plugin.saveData(this.plugin.settings);
+                                                                                                               this.display();
+                                                                                                           }));
 
-		new Setting(containerEl)
-			.setName('Shortcut for Align Block')
-			.setDesc('Use shortcut key to quickly insert \\begin{align*} \\end{align*} block. ' +
-				'Default: "Alt+Shift+A" (Mac: "Option+Shift+A")')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.addAlignBlock_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.addAlignBlock_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                                                                                           new Setting(containerEl)
+                                                                                                           .setName('Shortcut for Align Block')
+                                                                                                           .setDesc('Use shortcut key to quickly insert \\begin{align*} \\end{align*} block. ' +
+                                                                                                                    'Default: "Alt+Shift+A" (Mac: "Option+Shift+A")')
+                                                                                                           .addToggle((toggle) => toggle
+                                                                                                                      .setValue(this.plugin.settings.addAlignBlock_toggle)
+                                                                                                                      .onChange(async (value) => {
+                                                                                                                          this.plugin.settings.addAlignBlock_toggle = value;
+                                                                                                                          await this.plugin.saveData(this.plugin.settings);
+                                                                                                                          this.display();
+                                                                                                                      }));
 
-		new Setting(containerEl)
-			.setName('Align Block Parameter')
-			.setDesc('Set the text parameter in \\begin{parameter} and \\end{parameter}.')
-			.addText((text) => text
-				.setPlaceholder('default: align*')
-				.setValue(this.plugin.settings.addAlignBlock_parameter)
-				.onChange(async (value) => {
-					this.plugin.settings.addAlignBlock_parameter = value;
-					await this.plugin.saveData(this.plugin.settings);
-				}));
+                                                                                                                      new Setting(containerEl)
+                                                                                                                      .setName('Align Block Parameter')
+                                                                                                                      .setDesc('Set the text parameter in \\begin{parameter} and \\end{parameter}.')
+                                                                                                                      .addText((text) => text
+                                                                                                                               .setPlaceholder('default: align*')
+                                                                                                                               .setValue(this.plugin.settings.addAlignBlock_parameter)
+                                                                                                                               .onChange(async (value) => {
+                                                                                                                                   this.plugin.settings.addAlignBlock_parameter = value;
+                                                                                                                                   await this.plugin.saveData(this.plugin.settings);
+                                                                                                                               }));
 
-		new Setting(containerEl)
-			.setName('Shortcut for Matrix Block')
-			.setDesc('Use shortcut key to quickly  insert \\begin{pmatrix} \\end{pmatrix} block. ' +
-				'Default: "Alt+Shift+M" (Mac: "Option+Shift+M")')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.addMatrixBlock_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.addMatrixBlock_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                                                                                                               new Setting(containerEl)
+                                                                                                                               .setName('Shortcut for Matrix Block')
+                                                                                                                               .setDesc('Use shortcut key to quickly  insert \\begin{pmatrix} \\end{pmatrix} block. ' +
+                                                                                                                                        'Default: "Alt+Shift+M" (Mac: "Option+Shift+M")')
+                                                                                                                               .addToggle((toggle) => toggle
+                                                                                                                                          .setValue(this.plugin.settings.addMatrixBlock_toggle)
+                                                                                                                                          .onChange(async (value) => {
+                                                                                                                                              this.plugin.settings.addMatrixBlock_toggle = value;
+                                                                                                                                              await this.plugin.saveData(this.plugin.settings);
+                                                                                                                                              this.display();
+                                                                                                                                          }));
 
-		new Setting(containerEl)
-			.setName('Matrix Block Parameter')
-			.setDesc('Set the text parameter in \\begin{parameter} and \\end{parameter}.')
-			.addText((text) => text
-				.setPlaceholder('default: pmatrix')
-				.setValue(this.plugin.settings.addMatrixBlock_parameter)
-				.onChange(async (value) => {
-					this.plugin.settings.addMatrixBlock_parameter = value;
-					await this.plugin.saveData(this.plugin.settings);
-				}));
+                                                                                                                                          new Setting(containerEl)
+                                                                                                                                          .setName('Matrix Block Parameter')
+                                                                                                                                          .setDesc('Set the text parameter in \\begin{parameter} and \\end{parameter}.')
+                                                                                                                                          .addText((text) => text
+                                                                                                                                                   .setPlaceholder('default: pmatrix')
+                                                                                                                                                   .setValue(this.plugin.settings.addMatrixBlock_parameter)
+                                                                                                                                                   .onChange(async (value) => {
+                                                                                                                                                       this.plugin.settings.addMatrixBlock_parameter = value;
+                                                                                                                                                       await this.plugin.saveData(this.plugin.settings);
+                                                                                                                                                   }));
 
-		new Setting(containerEl)
-			.setName('Custom Shorthand')
-			.setDesc('Use two-letters custom shorthand for common latex strings. '+
-			'Eg, typing "al" followed by "space" key will replace with "\\alpha"')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.customShorthand_toggle)
-				.onChange(async (value) => {
-					this.plugin.settings.customShorthand_toggle = value;
-					await this.plugin.saveData(this.plugin.settings);
-					this.display();
-				}));
+                                                                                                                                                   new Setting(containerEl)
+                                                                                                                                                   .setName('Custom Shorthand')
+                                                                                                                                                   .setDesc('Use two-letters custom shorthand for common latex strings. '+
+                                                                                                                                                            'Eg, typing "al" followed by "space" key will replace with "\\alpha"')
+                                                                                                                                                   .addToggle((toggle) => toggle
+                                                                                                                                                              .setValue(this.plugin.settings.customShorthand_toggle)
+                                                                                                                                                              .onChange(async (value) => {
+                                                                                                                                                                  this.plugin.settings.customShorthand_toggle = value;
+                                                                                                                                                                  await this.plugin.saveData(this.plugin.settings);
+                                                                                                                                                                  this.display();
+                                                                                                                                                              }));
 
-		new Setting(containerEl)
-			.setName('Custom Shorthand Parameter')
-			.setDesc('Separate the two-letters shorthand and the string with ":" ;'+
-			'Separate each set of shorthands with ",".')
-			.addText((text) => text
-				.setValue(this.plugin.settings.customShorthand_parameter)
-				.onChange(async (value) => {
-					this.plugin.settings.customShorthand_parameter = value;
-					this.plugin.shorthand_array = value
-					.split(",").map(item=>item.split(":").map(s=>s.trim()));
-					await this.plugin.saveData(this.plugin.settings);
-				}));
-	};
+                                                                                                                                                              new Setting(containerEl)
+                                                                                                                                                              .setName('Custom Shorthand Parameter')
+                                                                                                                                                              .setDesc('Separate the two-letters shorthand and the string with ":" ;'+
+                                                                                                                                                                       'Separate each set of shorthands with ",".')
+                                                                                                                                                              .addText((text) => text
+                                                                                                                                                                       .setValue(this.plugin.settings.customShorthand_parameter)
+                                                                                                                                                                       .onChange(async (value) => {
+                                                                                                                                                                           this.plugin.settings.customShorthand_parameter = value;
+                                                                                                                                                                           this.plugin.shorthand_array = value
+                                                                                                                                                                           .split(",").map(item=>item.split(":").map(s=>s.trim()));
+                                                                                                                                                                           await this.plugin.saveData(this.plugin.settings);
+                                                                                                                                                                       }));
+    };
 }


### PR DESCRIPTION
Hey @joeyuping !
Sorry for not properly reviewing and testing my changes before making the last pull request.

Now the fix does not break the plugin in non-vim-mode anymore.

About the error message regarding "vim-mode-change": It seems to be caused by differences in "@types/codemirror" and "codemirror". I can't seem to be able to fix the error message, maybe it's just the typed package being an older version atm.
But in the end, it doesn't appear to cause any errors once the code is compiled to js, so it's really your decision whether this is acceptable for now or not.

And one last thing, as this is my fist contact with obsidian plugins, and typescript in general, I am not sure whether the added lines in the onunload method are correct, so it would be kind of you to confirm that, and make changes if required. 